### PR TITLE
feat: support code highlight when hover over tree node

### DIFF
--- a/components/CodeEditor.vue
+++ b/components/CodeEditor.vue
@@ -27,6 +27,33 @@ if (props.input)
       editorCursor.value = editor.getModel()!.getOffsetAt(e.position)
     })
   })
+
+let decorationsCollection:
+  | monaco.editor.IEditorDecorationsCollection
+  | undefined
+
+watchEffect(() => {
+  if (hoverLocation.value) {
+    decorationsCollection?.clear()
+    decorationsCollection =
+      container.value?.$editor?.createDecorationsCollection([
+        {
+          range: {
+            startColumn: hoverLocation.value.startColumn,
+            endColumn: hoverLocation.value.endColumn + 1,
+            startLineNumber: hoverLocation.value.startLineNumber,
+            endLineNumber: hoverLocation.value.endLineNumber,
+          },
+          options: {
+            isWholeLine: false,
+            className: 'monaco-bg-highlight',
+          },
+        },
+      ])
+  } else {
+    decorationsCollection?.clear()
+  }
+})
 </script>
 
 <template>
@@ -42,3 +69,9 @@ if (props.input)
     </div>
   </MonacoEditor>
 </template>
+
+<style>
+.monaco-bg-highlight {
+  --at-apply: 'bg-yellow-300/50 dark:bg-yellow-700/50';
+}
+</style>

--- a/components/CodeEditor.vue
+++ b/components/CodeEditor.vue
@@ -72,6 +72,6 @@ watchEffect(() => {
 
 <style>
 .monaco-bg-highlight {
-  --at-apply: 'bg-yellow-300/50 dark:bg-yellow-700/50';
+  --at-apply: 'bg-yellow-400/30 dark:bg-yellow-600/30';
 }
 </style>

--- a/components/CodeEditor.vue
+++ b/components/CodeEditor.vue
@@ -34,28 +34,23 @@ if (props.input) {
 
   const monaco = useMonaco()!
   watchEffect(() => {
-    if (!container.value) return
+    const editor = container.value?.$editor
+    if (!editor) return
 
-    if (hoverLocation.value) {
+    if (outputHoverRange.value) {
       decorationsCollection?.clear()
+      const start = editor.getModel()!.getPositionAt(outputHoverRange.value[0])
+      const end = editor.getModel()!.getPositionAt(outputHoverRange.value[1])
 
-      const start = container.value
-        ?.$editor!.getModel()!
-        .getPositionAt(hoverLocation.value.start!)
-      const end = container.value
-        ?.$editor!.getModel()!
-        .getPositionAt(hoverLocation.value.end!)
-
-      decorationsCollection =
-        container.value?.$editor?.createDecorationsCollection([
-          {
-            range: monaco.Range.fromPositions(start, end),
-            options: {
-              isWholeLine: false,
-              className: 'monaco-bg-highlight',
-            },
+      decorationsCollection = editor.createDecorationsCollection([
+        {
+          range: monaco.Range.fromPositions(start, end),
+          options: {
+            isWholeLine: false,
+            className: 'input-editor-highlight',
           },
-        ])
+        },
+      ])
     } else {
       decorationsCollection?.clear()
     }
@@ -78,7 +73,7 @@ if (props.input) {
 </template>
 
 <style>
-.monaco-bg-highlight {
+.input-editor-highlight {
   --at-apply: 'bg-yellow-400/30 dark:bg-yellow-600/30';
 }
 </style>

--- a/components/CodeEditor.vue
+++ b/components/CodeEditor.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { MonacoLanguage } from '#imports'
-import type * as monaco from 'monaco-editor'
+import type * as Monaco from 'monaco-editor'
 import type { MonacoEditor } from '#build/components'
 
 const props = defineProps<{
@@ -11,7 +11,7 @@ const code = defineModel<string>()
 
 const container = shallowRef<InstanceType<typeof MonacoEditor>>()
 
-const options = computed<monaco.editor.IStandaloneEditorConstructionOptions>(
+const options = computed<Monaco.editor.IStandaloneEditorConstructionOptions>(
   () => ({
     ...getSharedMonacoOptions(),
     fontSize: 14,
@@ -29,21 +29,27 @@ if (props.input)
   })
 
 let decorationsCollection:
-  | monaco.editor.IEditorDecorationsCollection
+  | Monaco.editor.IEditorDecorationsCollection
   | undefined
 
+const monaco = useMonaco()!
 watchEffect(() => {
+  if (!container.value) return
+
   if (hoverLocation.value) {
     decorationsCollection?.clear()
+
+    const start = container.value
+      ?.$editor!.getModel()!
+      .getPositionAt(hoverLocation.value.start!)
+    const end = container.value
+      ?.$editor!.getModel()!
+      .getPositionAt(hoverLocation.value.end!)
+
     decorationsCollection =
       container.value?.$editor?.createDecorationsCollection([
         {
-          range: {
-            startColumn: hoverLocation.value.startColumn,
-            endColumn: hoverLocation.value.endColumn + 1,
-            startLineNumber: hoverLocation.value.startLineNumber,
-            endLineNumber: hoverLocation.value.endLineNumber,
-          },
+          range: monaco.Range.fromPositions(start, end),
           options: {
             isWholeLine: false,
             className: 'monaco-bg-highlight',

--- a/components/CodeEditor.vue
+++ b/components/CodeEditor.vue
@@ -19,7 +19,7 @@ const options = computed<Monaco.editor.IStandaloneEditorConstructionOptions>(
   }),
 )
 
-if (props.input)
+if (props.input) {
   watchEffect(() => {
     const editor = toRaw(container.value?.$editor)
     if (!editor) return
@@ -28,38 +28,39 @@ if (props.input)
     })
   })
 
-let decorationsCollection:
-  | Monaco.editor.IEditorDecorationsCollection
-  | undefined
+  let decorationsCollection:
+    | Monaco.editor.IEditorDecorationsCollection
+    | undefined
 
-const monaco = useMonaco()!
-watchEffect(() => {
-  if (!container.value) return
+  const monaco = useMonaco()!
+  watchEffect(() => {
+    if (!container.value) return
 
-  if (hoverLocation.value) {
-    decorationsCollection?.clear()
+    if (hoverLocation.value) {
+      decorationsCollection?.clear()
 
-    const start = container.value
-      ?.$editor!.getModel()!
-      .getPositionAt(hoverLocation.value.start!)
-    const end = container.value
-      ?.$editor!.getModel()!
-      .getPositionAt(hoverLocation.value.end!)
+      const start = container.value
+        ?.$editor!.getModel()!
+        .getPositionAt(hoverLocation.value.start!)
+      const end = container.value
+        ?.$editor!.getModel()!
+        .getPositionAt(hoverLocation.value.end!)
 
-    decorationsCollection =
-      container.value?.$editor?.createDecorationsCollection([
-        {
-          range: monaco.Range.fromPositions(start, end),
-          options: {
-            isWholeLine: false,
-            className: 'monaco-bg-highlight',
+      decorationsCollection =
+        container.value?.$editor?.createDecorationsCollection([
+          {
+            range: monaco.Range.fromPositions(start, end),
+            options: {
+              isWholeLine: false,
+              className: 'monaco-bg-highlight',
+            },
           },
-        },
-      ])
-  } else {
-    decorationsCollection?.clear()
-  }
-})
+        ])
+    } else {
+      decorationsCollection?.clear()
+    }
+  })
+}
 </script>
 
 <template>

--- a/components/OutputTree.vue
+++ b/components/OutputTree.vue
@@ -1,5 +1,5 @@
 <template>
   <div overflow-auto pl4 text-sm leading-relaxed font-mono>
-    <AstProperty :value="ast" open />
+    <AstProperty :value="ast" open root />
   </div>
 </template>

--- a/components/ast/Property.vue
+++ b/components/ast/Property.vue
@@ -2,6 +2,7 @@
 const props = defineProps<{
   id?: string | number
   value?: any
+  root?: boolean
 }>()
 const open = defineModel<boolean>('open', { required: false })
 
@@ -35,26 +36,21 @@ const keyClass = computed(() => ({
 }))
 
 function handleMouseOver(event: MouseEvent) {
-  if (props.id === undefined) {
+  if (props.root) {
     event.stopPropagation()
-    hoverLocation.value = undefined
-  } else if (
-    typeof props.value?.start === 'number' &&
-    typeof props.value?.end === 'number'
-  ) {
-    event.stopPropagation()
-    const { start, end } = props.value
+    outputHoverRange.value = undefined
+  } else if (props.value) {
+    const range = currentParser.value.getAstLocation?.(props.value)
+    if (!range) return
 
-    hoverLocation.value = {
-      start,
-      end,
-    }
+    event.stopPropagation()
+    outputHoverRange.value = range
   }
 }
 
 function handleMouseLeave() {
-  if (props.id === undefined) {
-    hoverLocation.value = undefined
+  if (props.root) {
+    outputHoverRange.value = undefined
   }
 }
 
@@ -67,8 +63,8 @@ defineExpose({
   <div
     v-if="show"
     relative
-    @mouseleave="handleMouseLeave"
     @mouseover="handleMouseOver"
+    @mouseleave="handleMouseLeave"
   >
     <span
       v-if="openable"

--- a/components/ast/Property.vue
+++ b/components/ast/Property.vue
@@ -34,13 +34,55 @@ const keyClass = computed(() => ({
   'cursor-pointer hover:underline': openable.value,
 }))
 
+function handleMouseOver(event: MouseEvent) {
+  if (props.id === undefined) {
+    event.stopPropagation()
+    hoverLocation.value = undefined
+  } else if (props.value?.loc) {
+    event.stopPropagation()
+    const { start, end } = props.value.loc
+    hoverLocation.value = {
+      startColumn: start.column,
+      endColumn: end.column,
+      startLineNumber: start.line,
+      endLineNumber: end.line,
+    }
+  } else if (props.value?.start && props.value?.end) {
+    event.stopPropagation()
+    const { start, end } = props.value
+    const startColumn = start - code.value.slice(0, start).lastIndexOf('\n')
+    const endColumn = end - code.value.slice(0, end).lastIndexOf('\n') - 1
+
+    const startLine = code.value.slice(0, start).split('\n').length
+    const endLine = code.value.slice(0, end).split('\n').length
+
+    hoverLocation.value = {
+      startColumn,
+      endColumn,
+      startLineNumber: startLine,
+      endLineNumber: endLine,
+    }
+  }
+}
+
+function handleMouseLeave() {
+  if (props.id === undefined) {
+    hoverLocation.value = undefined
+  }
+}
+
 defineExpose({
   toggleOpen,
 })
 </script>
 
 <template>
-  <div v-if="show" relative>
+  <div
+    v-if="show"
+    relative
+    @mouseleave="handleMouseLeave"
+    @mouseover="handleMouseOver"
+  >
     <span
       v-if="openable"
       left="-3.5"

--- a/components/ast/Property.vue
+++ b/components/ast/Property.vue
@@ -38,29 +38,16 @@ function handleMouseOver(event: MouseEvent) {
   if (props.id === undefined) {
     event.stopPropagation()
     hoverLocation.value = undefined
-  } else if (props.value?.loc) {
-    event.stopPropagation()
-    const { start, end } = props.value.loc
-    hoverLocation.value = {
-      startColumn: start.column,
-      endColumn: end.column,
-      startLineNumber: start.line,
-      endLineNumber: end.line,
-    }
-  } else if (props.value?.start && props.value?.end) {
+  } else if (
+    typeof props.value?.start === 'number' &&
+    typeof props.value?.end === 'number'
+  ) {
     event.stopPropagation()
     const { start, end } = props.value
-    const startColumn = start - code.value.slice(0, start).lastIndexOf('\n')
-    const endColumn = end - code.value.slice(0, end).lastIndexOf('\n') - 1
-
-    const startLine = code.value.slice(0, start).split('\n').length
-    const endLine = code.value.slice(0, end).split('\n').length
 
     hoverLocation.value = {
-      startColumn,
-      endColumn,
-      startLineNumber: startLine,
-      endLineNumber: endLine,
+      start,
+      end,
     }
   }
 }

--- a/composables/state/parser.ts
+++ b/composables/state/parser.ts
@@ -1,6 +1,6 @@
 import json5 from 'json5'
 import ansiRegex from 'ansi-regex'
-import type { Language } from '#imports'
+import type { Language, Range } from '#imports'
 
 export const loading = ref<'load' | 'parse' | false>(false)
 export const code = ref('')
@@ -9,6 +9,7 @@ export const error = shallowRef<unknown>()
 export const rawOptions = ref('')
 export const parseCost = ref(0)
 export const editorCursor = ref<number>(0)
+export const outputHoverRange = ref<Range | undefined>()
 
 export const currentLanguageId = ref<Language>('javascript')
 export const currentParserId = ref<string | undefined>()

--- a/composables/state/tree-outputs.ts
+++ b/composables/state/tree-outputs.ts
@@ -1,0 +1,8 @@
+interface HoverLocation {
+  startColumn: number
+  endColumn: number
+  startLineNumber: number
+  endLineNumber: number
+}
+
+export const hoverLocation = ref<HoverLocation | undefined>()

--- a/composables/state/tree-outputs.ts
+++ b/composables/state/tree-outputs.ts
@@ -1,8 +1,6 @@
 interface HoverLocation {
-  startColumn: number
-  endColumn: number
-  startLineNumber: number
-  endLineNumber: number
+  start: number
+  end: number
 }
 
 export const hoverLocation = ref<HoverLocation | undefined>()

--- a/composables/state/tree-outputs.ts
+++ b/composables/state/tree-outputs.ts
@@ -1,6 +1,0 @@
-interface HoverLocation {
-  start: number
-  end: number
-}
-
-export const hoverLocation = ref<HoverLocation | undefined>()


### PR DESCRIPTION
### Description

Support highlights corresponding source code when hover on tree node.

#### Prview
![Kapture 2024-05-24 at 17 19 11](https://github.com/sxzz/ast-explorer/assets/38490578/0926d80a-898f-4845-973b-50fc277393d9)


### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
