### PR TITLE
feat: add rehype support for HTML parser

### DIFF
--- a/composables/constants.ts
+++ b/composables/constants.ts
@@ -1,2 +1,9 @@
-export const locationKeyList = ['loc', 'start', 'end', 'span', 'range']
+export const locationKeyList = [
+  'loc',
+  'start',
+  'end',
+  'span',
+  'range',
+  'position',
+]
 export const isSafari = globalThis.navigator?.vendor.includes('Apple Computer')

--- a/composables/location.ts
+++ b/composables/location.ts
@@ -37,6 +37,11 @@ const astLocationFields = {
     start: ['position', 'start', 'offset'],
     end: ['position', 'end', 'offset'],
   },
+  rehype: {
+    type: ['type'],
+    start: ['position', 'start', 'offset'],
+    end: ['position', 'end', 'offset'],
+  },
 } as const
 
 export function genGetAstLocation(

--- a/composables/location.ts
+++ b/composables/location.ts
@@ -32,12 +32,7 @@ const astLocationFields = {
     start: ['startIndex'],
     end: ['endIndex'],
   },
-  remark: {
-    type: ['type'],
-    start: ['position', 'start', 'offset'],
-    end: ['position', 'end', 'offset'],
-  },
-  rehype: {
+  positionOffset: {
     type: ['type'],
     start: ['position', 'start', 'offset'],
     end: ['position', 'end', 'offset'],

--- a/composables/parser/html.ts
+++ b/composables/parser/html.ts
@@ -1,6 +1,7 @@
 import { htmlTemplate } from './template'
 import type { LanguageOption, Parser } from './index'
 import type * as Htmlparser2 from 'htmlparser2'
+import type * as Rehype from 'rehype'
 
 // @unocss-include
 
@@ -25,9 +26,29 @@ const htmlparser2: Parser<typeof Htmlparser2, Htmlparser2.Options> = {
   getAstLocation: genGetAstLocation('htmlparser2'),
 }
 
+const rehypeAst: Parser<typeof Rehype> = {
+  id: 'rehype',
+  label: 'rehype',
+  icon: 'https://avatars.githubusercontent.com/u/25711728',
+  link: 'https://github.com/rehypejs/rehype',
+  editorLanguage: 'markdown',
+  options: {
+    configurable: false,
+    defaultValue: {},
+    editorLanguage: 'html',
+  },
+  pkgName: 'rehype',
+  init: (pkg) => importJsdelivr(pkg),
+  version: fetchVersion,
+  parse(code) {
+    return this.rehype().parse(code)
+  },
+  getAstLocation: genGetAstLocation('rehype'),
+}
+
 export const html: LanguageOption = {
   label: 'HTML',
   icon: 'i-vscode-icons:file-type-html',
-  parsers: [htmlparser2],
+  parsers: [htmlparser2, rehypeAst],
   codeTemplate: htmlTemplate,
 }

--- a/composables/parser/html.ts
+++ b/composables/parser/html.ts
@@ -31,7 +31,7 @@ const rehypeAst: Parser<typeof Rehype> = {
   label: 'rehype',
   icon: 'https://avatars.githubusercontent.com/u/25711728',
   link: 'https://github.com/rehypejs/rehype',
-  editorLanguage: 'markdown',
+  editorLanguage: 'html',
   options: {
     configurable: false,
     defaultValue: {},

--- a/composables/parser/html.ts
+++ b/composables/parser/html.ts
@@ -35,7 +35,7 @@ const rehypeAst: Parser<typeof Rehype> = {
   options: {
     configurable: false,
     defaultValue: {},
-    editorLanguage: 'html',
+    editorLanguage: 'javascript',
   },
   pkgName: 'rehype',
   init: (pkg) => importJsdelivr(pkg),
@@ -43,7 +43,7 @@ const rehypeAst: Parser<typeof Rehype> = {
   parse(code) {
     return this.rehype().parse(code)
   },
-  getAstLocation: genGetAstLocation('rehype'),
+  getAstLocation: genGetAstLocation('positionOffset'),
 }
 
 export const html: LanguageOption = {

--- a/composables/parser/markdown.ts
+++ b/composables/parser/markdown.ts
@@ -20,7 +20,7 @@ const remarkAst: Parser<typeof Remark> = {
   parse(code) {
     return this.remark().parse(code)
   },
-  getAstLocation: genGetAstLocation('remark'),
+  getAstLocation: genGetAstLocation('positionOffset'),
 }
 
 export const markdown: LanguageOption = {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "nuxt-monaco-editor": "^1.2.9",
     "nuxt-umami": "^3.0.2",
     "postcss": "^8.4.47",
+    "rehype": "^13.0.2",
     "remark": "^15.0.1",
     "serve": "^14.2.3",
     "svelte": "^4.2.19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       postcss:
         specifier: ^8.4.47
         version: 8.4.47
+      rehype:
+        specifier: ^13.0.2
+        version: 13.0.2
       remark:
         specifier: ^15.0.1
         version: 15.0.1
@@ -3014,11 +3017,23 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hast-util-from-html@2.0.3:
+    resolution: {integrity: sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==}
+
+  hast-util-from-parse5@8.0.1:
+    resolution: {integrity: sha512-Er/Iixbc7IEa7r/XLtuG52zoqn/b3Xng/w6aZQ0xGVxzhw5xUFxcRqdPzP6yFi/4HBYRaifaI5fQ1RH8n0ZeOQ==}
+
+  hast-util-parse-selector@4.0.0:
+    resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
+
   hast-util-to-html@9.0.3:
     resolution: {integrity: sha512-M17uBDzMJ9RPCqLMO92gNNUDuBSq10a25SDBI08iCCxmorf4Yy6sYHK57n9WAbRAAaU+DuR4W6GN9K4DFZesYg==}
 
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  hastscript@8.0.0:
+    resolution: {integrity: sha512-dMOtzCEd3ABUeSIISmrETiKuyydk1w0pa+gE/uormcTpSYuaNJPbX1NU3JLyscSLjwAQM8bWMhhIlnCqnRvDTw==}
 
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
@@ -3884,6 +3899,9 @@ packages:
   parse-url@8.1.0:
     resolution: {integrity: sha512-xDvOoLU5XRrcOZvnI6b8zA6n9O9ejNk/GExuz1yBuWUGn9KA97GI6HTs6u02wKara1CeVmZhH+0TZFdWScR89w==}
 
+  parse5@7.1.2:
+    resolution: {integrity: sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -4251,6 +4269,15 @@ packages:
   regjsparser@0.10.0:
     resolution: {integrity: sha512-qx+xQGZVsy55CH0a1hiVwHmqjLryfh7wQyF5HO07XJ9f7dQMY/gPQHhlyDkIzJKC+x2fUCpCcUODUUUFrm7SHA==}
     hasBin: true
+
+  rehype-parse@9.0.1:
+    resolution: {integrity: sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==}
+
+  rehype-stringify@10.0.1:
+    resolution: {integrity: sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==}
+
+  rehype@13.0.2:
+    resolution: {integrity: sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==}
 
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
@@ -4892,6 +4919,9 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  vfile-location@5.0.3:
+    resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
+
   vfile-message@4.0.2:
     resolution: {integrity: sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==}
 
@@ -5068,6 +5098,9 @@ packages:
   watchpack@2.4.2:
     resolution: {integrity: sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==}
     engines: {node: '>=10.13.0'}
+
+  web-namespaces@2.0.1:
+    resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -8489,6 +8522,30 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-from-html@2.0.3:
+    dependencies:
+      '@types/hast': 3.0.4
+      devlop: 1.1.0
+      hast-util-from-parse5: 8.0.1
+      parse5: 7.1.2
+      vfile: 6.0.3
+      vfile-message: 4.0.2
+
+  hast-util-from-parse5@8.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      hastscript: 8.0.0
+      property-information: 6.5.0
+      vfile: 6.0.3
+      vfile-location: 5.0.3
+      web-namespaces: 2.0.1
+
+  hast-util-parse-selector@4.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   hast-util-to-html@9.0.3:
     dependencies:
       '@types/hast': 3.0.4
@@ -8506,6 +8563,14 @@ snapshots:
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
+
+  hastscript@8.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      hast-util-parse-selector: 4.0.0
+      property-information: 6.5.0
+      space-separated-tokens: 2.0.2
 
   he@1.2.0: {}
 
@@ -9690,6 +9755,10 @@ snapshots:
     dependencies:
       parse-path: 7.0.0
 
+  parse5@7.1.2:
+    dependencies:
+      entities: 4.5.0
+
   parseurl@1.3.3: {}
 
   path-browserify@1.0.1: {}
@@ -10030,6 +10099,25 @@ snapshots:
   regjsparser@0.10.0:
     dependencies:
       jsesc: 0.5.0
+
+  rehype-parse@9.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-from-html: 2.0.3
+      unified: 11.0.5
+
+  rehype-stringify@10.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.3
+      unified: 11.0.5
+
+  rehype@13.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      rehype-parse: 9.0.1
+      rehype-stringify: 10.0.1
+      unified: 11.0.5
 
   remark-parse@11.0.0:
     dependencies:
@@ -10776,6 +10864,11 @@ snapshots:
 
   vary@1.1.2: {}
 
+  vfile-location@5.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile: 6.0.3
+
   vfile-message@4.0.2:
     dependencies:
       '@types/unist': 3.0.3
@@ -10957,6 +11050,8 @@ snapshots:
     dependencies:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
+
+  web-namespaces@2.0.1: {}
 
   webidl-conversions@3.0.1: {}
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

remark and rehype is quite useful when processing markdown and HTML, [Nolebase Integrations](https://github.com/nolebase/integrations) heavily rely on these two parsers and its family toolsets, I want to propose a support to visualize and explore the hast (which is used for rehype parsed AST, mdast for remark).

Added support of `rehype`.

<img width="1635" alt="image" src="https://github.com/user-attachments/assets/2acd08b2-ae96-4f20-8817-9cfa48d51bad">

### Linked Issues

None.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

unifiedjs's family (remark, rehype, retext) all satisfy unist spec, for location getter, rehype is the same with remark.

https://github.com/rehypejs/rehype