### PR TITLE
fix: add cache for getAstTitle in typescript parser

### DIFF
--- a/composables/parser/javascript/typescript.ts
+++ b/composables/parser/javascript/typescript.ts
@@ -35,7 +35,14 @@ export const typescript: Parser<
   },
 }
 
+const cache = new WeakMap<
+  typeof Typescript,
+  Record<Typescript.SyntaxKind, string>
+>()
+
 function getSyntaxKind(ts: typeof Typescript, kind: Typescript.SyntaxKind) {
+  const cached = cache.get(ts)
+  if (cached) return cached[kind]
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const syntaxKinds = {} as Record<Typescript.SyntaxKind, string>
   for (const [key, value] of Object.entries(ts.SyntaxKind)) {
@@ -43,5 +50,6 @@ function getSyntaxKind(ts: typeof Typescript, kind: Typescript.SyntaxKind) {
       syntaxKinds[value] = key
     }
   }
+  cache.set(ts, syntaxKinds)
   return syntaxKinds[kind]
 }


### PR DESCRIPTION
### Description

I left [this comment](https://github.com/sxzz/ast-explorer/commit/90b634e5446781cec269fbc51389320de6a1b975#r149342860) on a previous PR and I since wonder what was the perf impact. It was less bad than expected: 4ms per keystroke on my Mac for a 1.4k lines file (Vite's optimizer/index.ts). But I don't think people will use it with that much code. Anyway once checkout it was cheap to make the PR, I let you decide if you want to merge it or not.