### PR TITLE
feat(editor): no ligatures

### DIFF
--- a/components/CodeEditor.vue
+++ b/components/CodeEditor.vue
@@ -16,7 +16,6 @@ const options = computed<Monaco.editor.IStandaloneEditorConstructionOptions>(
   () => ({
     ...getSharedMonacoOptions(),
     fontSize: 14,
-    fontLigatures: true,
   }),
 )
 


### PR DESCRIPTION
before|after
---|---
<img width="1512" alt="Screenshot 2025-03-04 at 10 32 32" src="https://github.com/user-attachments/assets/1ac22b25-ff53-4a62-a494-497f887bd3a2" /> | <img width="1511" alt="Screenshot 2025-03-04 at 10 32 19" src="https://github.com/user-attachments/assets/8feced3e-2ea8-407b-afae-03a5b00d2baf" />

In Safari this fixes some problems with the cursor displaying at the wrong place too