### PR TITLE
support optionalChainingAssign for babel parser

### DIFF
--- a/composables/parser/javascript/BabelGui.vue
+++ b/composables/parser/javascript/BabelGui.vue
@@ -97,6 +97,24 @@ const decoratorsLegacy = useOptions(
     }
   },
 )
+
+const optionalChainingAssign = useOptions(
+  (opt: ParserOptions) =>
+    opt.plugins?.some(
+      (n) => Array.isArray(n) && n[0] === 'optionalChainingAssign',
+    ),
+  (value, opt) => {
+    if (!Array.isArray(opt.plugins)) opt.plugins = []
+    if (value) {
+      opt.plugins.push(['optionalChainingAssign', { version: '2023-07' }])
+    } else {
+      opt.plugins = opt.plugins.filter(
+        (n) => !Array.isArray(n) || n[0] !== 'optionalChainingAssign',
+      )
+    }
+  },
+)
+
 const decoratorAutoAccessors = usePlugin('decoratorAutoAccessors', [decorators])
 const decimal = usePlugin('decimal')
 const deferredImportEvaluation = usePlugin('deferredImportEvaluation')
@@ -108,7 +126,6 @@ const functionSent = usePlugin('functionSent')
 const deprecatedImportAssert = usePlugin('deprecatedImportAssert')
 const importReflection = usePlugin('importReflection')
 const moduleBlocks = usePlugin('moduleBlocks')
-const optionalChainingAssign = usePlugin('optionalChainingAssign')
 const partialApplication = usePlugin('partialApplication')
 const pipelineOperator = usePlugin('pipelineOperator')
 const recordAndTuple = usePlugin('recordAndTuple')


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This PR adds support for optionalChainingAssign in the Babel parser. It ensures that optional chaining assignments are correctly parsed and handled within the AST.


