### PR TITLE
fix: add coop/coep headers to editor worker assets

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -28,6 +28,17 @@ export default defineNuxtConfig({
         headers: crossOriginHeaders,
       },
     },
+    vercel: {
+      config: {
+        routes: [
+          {
+            src: '^/_nuxt/(.*)$',
+            // @ts-ignore
+            headers: crossOriginHeaders,
+          },
+        ],
+      },
+    },
   },
   devtools: {
     enabled: true,

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,5 +1,11 @@
 import process from 'node:process'
 
+// cross origin isolation is required since oxc-parser uses shared array buffer
+const crossOriginHeaders = {
+  'Cross-Origin-Embedder-Policy': 'require-corp',
+  'Cross-Origin-Opener-Policy': 'same-origin',
+}
+
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   modules: ['@unocss/nuxt', '@vueuse/nuxt', 'nuxt-monaco-editor', 'nuxt-umami'],
@@ -13,20 +19,13 @@ export default defineNuxtConfig({
       },
     },
     server: {
-      headers: {
-        'Cross-Origin-Embedder-Policy': 'require-corp',
-        'Cross-Origin-Opener-Policy': 'same-origin',
-      }
-    }
+      headers: crossOriginHeaders,
+    },
   },
   nitro: {
     routeRules: {
       '/**': {
-        headers: {
-          // cross origin isolation is required since oxc-parser uses shared array buffer
-          'Cross-Origin-Embedder-Policy': 'require-corp',
-          'Cross-Origin-Opener-Policy': 'same-origin',
-        },
+        headers: crossOriginHeaders,
       },
     },
   },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -12,6 +12,12 @@ export default defineNuxtConfig({
         path: 'pathe',
       },
     },
+    server: {
+      headers: {
+        'Cross-Origin-Embedder-Policy': 'require-corp',
+        'Cross-Origin-Opener-Policy': 'same-origin',
+      }
+    }
   },
   nitro: {
     routeRules: {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -32,8 +32,8 @@ export default defineNuxtConfig({
       config: {
         routes: [
           {
-            src: '^/_nuxt/(.*)$',
-            // @ts-ignore
+            src: '.*',
+            // @ts-expect-error - type dismatch in `nitropack`
             headers: crossOriginHeaders,
           },
         ],


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

I think I figured out how to fix dev, but the deployed version might need a config on vercel side. It looks like `routeRules` only handles root page and doesn't apply to `/_nust/...` assets.

### Linked Issues

- Closes https://github.com/sxzz/ast-explorer/issues/152

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
