### PR TITLE
feat: add `ultrahtml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Feel free to add more languages and parsers via PR!
 - HTML
   - [htmlparser2](https://feedic.com/htmlparser2/)
   - [rehype](https://github.com/rehypejs/rehype)
+  - [ultrahtml](https://github.com/natemoo-re/ultrahtml/)
 - JSON
   - [json-to-ast](https://github.com/vtrushin/json-to-ast)
   - [moma](https://www.npmjs.com/package/@humanwhocodes/momoa)

--- a/app/composables/location.ts
+++ b/app/composables/location.ts
@@ -63,6 +63,11 @@ const nodeLocationFields = {
     start: ['loc', 'start', 'offset'],
     end: ['loc', 'end', 'offset'],
   },
+  ultrahtml: {
+    type: ['type'],
+    start: ['loc', '0', 'start'],
+    end: ['loc', '1', 'end'],
+  },
 } as const
 
 export function genGetNodeLocation(

--- a/app/parser/html.ts
+++ b/app/parser/html.ts
@@ -3,6 +3,7 @@ import type { LanguageOption, Parser } from './index'
 import type * as HtmlEslintParser from '@html-eslint/parser'
 import type * as Htmlparser2 from 'htmlparser2'
 import type * as Rehype from 'rehype'
+import type * as Ultrahtml from 'ultrahtml'
 
 // @unocss-include
 
@@ -65,9 +66,28 @@ const htmlEslintParser: Parser<
   getNodeLocation: genGetNodeLocation('range'),
 }
 
+const ultrahtmlParser: Parser<typeof Ultrahtml> = {
+  id: 'ultrahtml-parser',
+  label: 'ultrahtml',
+  icon: 'i-vscode-icons:file-type-html',
+  link: 'https://github.com/natemoo-re/ultrahtml/',
+  editorLanguage: 'html',
+  options: {
+    configurable: false,
+    defaultValue: '{}',
+    editorLanguage: 'javascript',
+  },
+  pkgName: 'ultrahtml',
+  parse(code) {
+    return this.parse(code)
+  },
+  getNodeLocation: genGetNodeLocation('ultrahtml'),
+  hideKeys: ['parent'],
+}
+
 export const html: LanguageOption = {
   label: 'HTML',
   icon: 'i-vscode-icons:file-type-html',
-  parsers: [htmlparser2, rehypeAst, htmlEslintParser],
+  parsers: [htmlparser2, rehypeAst, htmlEslintParser, ultrahtmlParser],
   codeTemplate: htmlTemplate,
 }

--- a/app/parser/html.ts
+++ b/app/parser/html.ts
@@ -1,10 +1,3 @@
-import {
-  COMMENT_NODE,
-  DOCTYPE_NODE,
-  DOCUMENT_NODE,
-  ELEMENT_NODE,
-  TEXT_NODE,
-} from 'ultrahtml'
 import { htmlTemplate } from './template'
 import type { LanguageOption, Parser } from './index'
 import type * as HtmlEslintParser from '@html-eslint/parser'
@@ -90,15 +83,15 @@ const ultrahtmlParser: Parser<typeof Ultrahtml> = {
   },
   valueHint(key, value) {
     if (key !== 'type') return
-    if (value === DOCUMENT_NODE) {
+    if (value === this.DOCUMENT_NODE) {
       return 'DOCUMENT_NODE'
-    } else if (value === ELEMENT_NODE) {
+    } else if (value === this.ELEMENT_NODE) {
       return 'ELEMENT_NODE'
-    } else if (value === TEXT_NODE) {
+    } else if (value === this.TEXT_NODE) {
       return 'TEXT_NODE'
-    } else if (value === COMMENT_NODE) {
+    } else if (value === this.COMMENT_NODE) {
       return 'COMMENT_NODE'
-    } else if (value === DOCTYPE_NODE) {
+    } else if (value === this.DOCTYPE_NODE) {
       return 'DOCTYPE_NODE'
     } else {
       return `NodeType.${value}`

--- a/app/parser/html.ts
+++ b/app/parser/html.ts
@@ -1,3 +1,10 @@
+import {
+  COMMENT_NODE,
+  DOCTYPE_NODE,
+  DOCUMENT_NODE,
+  ELEMENT_NODE,
+  TEXT_NODE,
+} from 'ultrahtml'
 import { htmlTemplate } from './template'
 import type { LanguageOption, Parser } from './index'
 import type * as HtmlEslintParser from '@html-eslint/parser'
@@ -80,6 +87,22 @@ const ultrahtmlParser: Parser<typeof Ultrahtml> = {
   pkgName: 'ultrahtml',
   parse(code) {
     return this.parse(code)
+  },
+  valueHint(key, value) {
+    if (key !== 'type') return
+    if (value === DOCUMENT_NODE) {
+      return 'DOCUMENT_NODE'
+    } else if (value === ELEMENT_NODE) {
+      return 'ELEMENT_NODE'
+    } else if (value === TEXT_NODE) {
+      return 'TEXT_NODE'
+    } else if (value === COMMENT_NODE) {
+      return 'COMMENT_NODE'
+    } else if (value === DOCTYPE_NODE) {
+      return 'DOCTYPE_NODE'
+    } else {
+      return `NodeType.${value}`
+    }
   },
   getNodeLocation: genGetNodeLocation('ultrahtml'),
   hideKeys: ['parent'],

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "svelte": "^5.37.0",
     "tsx": "^4.20.3",
     "typescript": "~5.8.3",
+    "ultrahtml": "^1.6.0",
     "unenv": "^2.0.0-rc.19",
     "unocss": "^66.3.3",
     "unplugin-replace": "^0.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,9 @@ importers:
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
+      ultrahtml:
+        specifier: ^1.6.0
+        version: 1.6.0
       unenv:
         specifier: ^2.0.0-rc.19
         version: 2.0.0-rc.19


### PR DESCRIPTION
### Description

This PR introduces [`ultrahtml`](https://github.com/natemoo-re/ultrahtml/) as a new HTML parsing option for the AST Explorer.

Since `ultrahtml` is used in both Nuxt and Astro, this addition might be helpful for those maintaining or contributing to these frameworks.

<img width="1440" height="900" alt="ultrahtml screenshot" src="https://github.com/user-attachments/assets/fd82d9a7-fe28-4165-b78a-44d1c3b64fbd" />

### Linked Issues

N/A

### Additional context

N/A