### PR TITLE
refactor: improve bracket spacing in AST display

### DIFF
--- a/app/components/ast/Brackets.vue
+++ b/app/components/ast/Brackets.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
-const props = defineProps<{ data: any; open?: boolean }>()
+const props = defineProps<{
+  data: any
+  open?: boolean
+}>()
 const start = computed(() => (Array.isArray(props.data) ? '[' : '{'))
 const end = computed(() => (Array.isArray(props.data) ? ']' : '}'))
 </script>

--- a/app/components/ast/Brackets.vue
+++ b/app/components/ast/Brackets.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
-const props = defineProps<{ data: any }>()
+const props = defineProps<{ data: any; open?: boolean }>()
 const start = computed(() => (Array.isArray(props.data) ? '[' : '{'))
 const end = computed(() => (Array.isArray(props.data) ? ']' : '}'))
 </script>
 
 <template>
-  <span op70>{{ start }}&nbsp;</span>
+  <span op70>{{ start }}{{ open ? '' : '&nbsp;' }}</span>
   <slot />
-  <span op70>&nbsp;{{ end }}</span>
+  <span op70>{{ open ? '' : '&nbsp;' }}{{ end }}</span>
 </template>

--- a/app/components/ast/Value.vue
+++ b/app/components/ast/Value.vue
@@ -55,7 +55,7 @@ watchEffect(() => {
 
 <template>
   <template v-if="typeof rawValue === 'object' && rawValue != null">
-    <AstBrackets :data="rawValue">
+    <AstBrackets :data="rawValue" open>
       <div v-if="hasChildren" ml6>
         <template v-for="(item, key) of rawValue" :key="key">
           <AstProperty

--- a/app/components/output/Tree.vue
+++ b/app/components/output/Tree.vue
@@ -18,7 +18,7 @@ function showDialog() {
       font-mono
       :style="astTreeStyles"
     >
-      <AstProperty :value="ast" root open />
+      <AstProperty :value="ast" open root />
     </div>
     <button
       absolute


### PR DESCRIPTION
### Description

This PR introduces an improvement to the visual formatting of brackets in the AST display by adding conditional spacing control.

This is just a minor detail I happened to notice—totally okay to close if it doesn't feel necessary.

**Before**
<img width="801" height="469" alt="before" src="https://github.com/user-attachments/assets/4f400b19-7aa8-46c3-b1c8-e024854488eb" />


**After**
<img width="801" height="468" alt="after" src="https://github.com/user-attachments/assets/fb94ee87-9ca5-4e40-8c25-8dba6454d1bb" />


### Linked Issues

N/A

### Additional context

N/A
