### PR TITLE
feat: add TypeScript JSON parser support

### DIFF
--- a/app/parser/json/index.ts
+++ b/app/parser/json/index.ts
@@ -3,10 +3,11 @@ import type { LanguageOption } from '..'
 import { jsonToAst } from './json-to-ast'
 import { jsoncEslintParser } from './jsonc-eslint-parser'
 import { momoa } from './momoa'
+import { typescript } from './typescript'
 
 export const json: LanguageOption = {
   label: 'JSON',
   icon: 'i-vscode-icons:file-type-json',
-  parsers: [jsonToAst, momoa, jsoncEslintParser],
+  parsers: [jsonToAst, momoa, jsoncEslintParser, typescript],
   codeTemplate: jsonTemplate,
 }

--- a/app/parser/json/typescript.ts
+++ b/app/parser/json/typescript.ts
@@ -1,0 +1,73 @@
+import type { Parser } from '../index'
+import type Typescript from 'typescript'
+
+// @unocss-include
+
+export const typescript: Parser<typeof Typescript, Record<string, never>> = {
+  id: 'typescript-json',
+  label: 'typescript',
+  icon: 'i-vscode-icons:file-type-typescript-official',
+  link: 'https://www.typescriptlang.org/',
+  editorLanguage: 'json',
+  options: {
+    configurable: false,
+    defaultValue: {},
+    editorLanguage: 'json',
+  },
+  pkgName: 'typescript',
+  init: (url) => resolveDefault(importUrl(url)),
+  async version() {
+    return (await this).version
+  },
+  parse(code) {
+    return this.parseJsonText('file.json', code)
+  },
+  getNodeLocation(node) {
+    if (!node || typeof node !== 'object') return
+    if (node.pos !== undefined && node.end !== undefined) {
+      return [node.pos, node.end]
+    }
+  },
+  nodeTitle(value) {
+    const kind: Typescript.SyntaxKind | undefined = value?.kind
+    if (kind == null) return
+    return getSyntaxKind(this, kind)
+  },
+  valueHint(key, value) {
+    if (typeof value !== 'number') return
+
+    switch (key) {
+      case 'kind':
+        return `SyntaxKind.${getSyntaxKind(this, value)}`
+      case 'flags':
+        return getNodeFlags(this, value)
+    }
+  },
+  hideKeys: ['parent'],
+}
+
+const cache = new WeakMap<
+  typeof Typescript,
+  Record<Typescript.SyntaxKind, string>
+>()
+
+function getSyntaxKind(ts: typeof Typescript, kind: Typescript.SyntaxKind) {
+  const cached = cache.get(ts)
+  if (cached) return cached[kind]
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  const syntaxKinds = {} as Record<Typescript.SyntaxKind, string>
+  for (const [key, value] of Object.entries(ts.SyntaxKind)) {
+    if (typeof value === 'number' && !syntaxKinds[value]) {
+      syntaxKinds[value] = key
+    }
+  }
+  cache.set(ts, syntaxKinds)
+  return syntaxKinds[kind]
+}
+
+function getNodeFlags(ts: typeof Typescript, flags: Typescript.NodeFlags) {
+  const flagNames = Object.keys(ts.NodeFlags).filter(
+    (key) => flags & (ts.NodeFlags as any)[key],
+  )
+  return flagNames.map((name) => `NodeFlags.${name}`).join(' | ')
+}

--- a/app/parser/json/typescript.ts
+++ b/app/parser/json/typescript.ts
@@ -1,23 +1,17 @@
+import { typescript as base } from '../javascript/typescript'
 import type { Parser } from '../index'
 import type Typescript from 'typescript'
 
 // @unocss-include
 
 export const typescript: Parser<typeof Typescript, Record<string, never>> = {
+  ...base,
   id: 'typescript-json',
-  label: 'typescript',
-  icon: 'i-vscode-icons:file-type-typescript-official',
-  link: 'https://www.typescriptlang.org/',
   editorLanguage: 'json',
   options: {
     configurable: false,
     defaultValue: {},
     editorLanguage: 'json',
-  },
-  pkgName: 'typescript',
-  init: (url) => resolveDefault(importUrl(url)),
-  async version() {
-    return (await this).version
   },
   parse(code) {
     return this.parseJsonText('file.json', code)
@@ -28,46 +22,5 @@ export const typescript: Parser<typeof Typescript, Record<string, never>> = {
       return [node.pos, node.end]
     }
   },
-  nodeTitle(value) {
-    const kind: Typescript.SyntaxKind | undefined = value?.kind
-    if (kind == null) return
-    return getSyntaxKind(this, kind)
-  },
-  valueHint(key, value) {
-    if (typeof value !== 'number') return
-
-    switch (key) {
-      case 'kind':
-        return `SyntaxKind.${getSyntaxKind(this, value)}`
-      case 'flags':
-        return getNodeFlags(this, value)
-    }
-  },
-  hideKeys: ['parent'],
-}
-
-const cache = new WeakMap<
-  typeof Typescript,
-  Record<Typescript.SyntaxKind, string>
->()
-
-function getSyntaxKind(ts: typeof Typescript, kind: Typescript.SyntaxKind) {
-  const cached = cache.get(ts)
-  if (cached) return cached[kind]
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-  const syntaxKinds = {} as Record<Typescript.SyntaxKind, string>
-  for (const [key, value] of Object.entries(ts.SyntaxKind)) {
-    if (typeof value === 'number' && !syntaxKinds[value]) {
-      syntaxKinds[value] = key
-    }
-  }
-  cache.set(ts, syntaxKinds)
-  return syntaxKinds[kind]
-}
-
-function getNodeFlags(ts: typeof Typescript, flags: Typescript.NodeFlags) {
-  const flagNames = Object.keys(ts.NodeFlags).filter(
-    (key) => flags & (ts.NodeFlags as any)[key],
-  )
-  return flagNames.map((name) => `NodeFlags.${name}`).join(' | ')
+  gui: undefined,
 }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
Adds TypeScript as a new JSON parser option using the `parseJsonText()` API. Users can now choose TypeScript alongside the existing `json-to-ast`, `momoa`, and `jsonc-eslint-parser` options.

### Linked Issues

Closes #200.

### Additional context
