### PR TITLE
feat: add ArkTS AST

### DIFF
--- a/app/parser/javascript/index.ts
+++ b/app/parser/javascript/index.ts
@@ -1,13 +1,13 @@
 import { javascriptTemplate } from '../template'
 import type { LanguageOption } from '..'
 import { acorn, acornLoose } from './acorn'
-import { arkts } from './arkts'
 import { babel } from './babel'
 import { espree, tsEslint } from './eslint'
 import { esprimaNext } from './esprima-next'
 import { flow } from './flow'
 import { hermes } from './hermes'
 import { meriyah } from './meriyah'
+import { ohosTypescript } from './ohos-typescript'
 import { oxc } from './oxc'
 import { swc } from './swc'
 import { typescript } from './typescript'
@@ -23,13 +23,13 @@ export const javascript: LanguageOption = {
     acorn,
     acornLoose,
     typescript,
-    arkts,
     espree,
     tsEslint,
     esprimaNext,
     flow,
     hermes,
     meriyah,
+    ohosTypescript,
   ],
   codeTemplate: javascriptTemplate,
 }

--- a/app/parser/javascript/ohos-typescript.ts
+++ b/app/parser/javascript/ohos-typescript.ts
@@ -1,20 +1,20 @@
 import type { Parser } from '..'
-import type Typescript from 'typescript'
+import type Typescript from 'ohos-typescript'
 
-export const arkts: Parser<
+export const ohosTypescript: Parser<
   typeof Typescript,
   Typescript.CreateSourceFileOptions & { scriptKind: Typescript.ScriptKind }
 > = {
-  id: 'arkts',
-  label: 'arkts',
+  id: 'ohos-typescript',
+  label: 'ohos-typescript',
   // @unocss-include
   icon: 'https://cdn.jsdelivr.net/gh/groupguanfang/ohos-typescript-browserify/logo.png',
-  link: 'https://gitcode.com/openharmony/third_party_typescript/',
+  link: 'https://gitcode.com/openharmony/third_party_typescript',
   options: {
     configurable: true,
     defaultValue: {
       languageVersion: 99,
-      scriptKind: 8 as any,
+      scriptKind: 8,
     },
     editorLanguage: 'json',
   },
@@ -24,10 +24,6 @@ export const arkts: Parser<
     return (await this).version
   },
   parse(code, { scriptKind, ...options }) {
-    // ArkTS's ts.createSourceFile allow 6 options, the last one is a compiler options settings
-    // ArkTS have some special compiler options, like etsAnnotationsEnable: true will enable
-    // the Java like annotations support, which is not supported by TypeScript.
-    // @ts-expect-error
     return this.createSourceFile('foo.ts', code, options, true, scriptKind, {
       etsAnnotationsEnable: true,
     })

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "meriyah": "^6.1.4",
     "nuxt": "4.2.0",
     "nuxt-monaco-editor": "^1.4.0",
+    "ohos-typescript": "4.9.5-r10",
     "oxc-parser": "^0.95.0",
     "php-parser": "^3.2.5",
     "postcss": "^8.5.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ importers:
       nuxt-monaco-editor:
         specifier: ^1.4.0
         version: 1.4.0(magicast@0.3.5)(monaco-editor@0.54.0)(rolldown-vite@7.1.19(@types/node@24.8.1)(esbuild@0.25.11)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.5)(yaml@2.8.1))
+      ohos-typescript:
+        specifier: 4.9.5-r10
+        version: 4.9.5-r10
       oxc-parser:
         specifier: ^0.95.0
         version: 0.95.0
@@ -4344,6 +4347,11 @@ packages:
 
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
+
+  ohos-typescript@4.9.5-r10:
+    resolution: {integrity: sha512-UyLXhBnUe5H4HGugf1ocYPawod0Q4ituiUATYoHIR5y4uxnH4+8ddD39aeLgcQah1YMv2DRKRaL9W1jgtnbEtQ==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
 
   on-change@6.0.0:
     resolution: {integrity: sha512-J7kocOS+ZNyjmW6tUUTtA7jLt8GjQlrOdz9z3yLNTvdsswO+b5lYSdMVzDczWnooyFAkkQiKyap5g/Zba+cFRA==}
@@ -10685,6 +10693,8 @@ snapshots:
       ufo: 1.6.1
 
   ohash@2.0.11: {}
+
+  ohos-typescript@4.9.5-r10: {}
 
   on-change@6.0.0: {}
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

I added the AST of the ArkTS language, which is a superset of TypeScript. The original is a fork of TypeScript, so we only need to modify a small number of parser options to display it properly on ast-explorer.dev.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

I encountered some issues, as ohos-typescript itself uses the node:perf_hooks package which is only available in the node.js environment, making it unable to run directly in the browser via jsdelivr. 

Therefore, I created another repository [ohos-typescript-browserify](https://github.com/Groupguanfang/ohos-typescript-browserify), aiming to repack it using tsdown, and use alias to introduce a simple node:perf_hooks polyfill to repack it, and published it on npm: [ohos-typescript-browserify](https://www.npmjs.com/package/ohos-typescript-browserify).

Additionally, I uploaded the ArkTS icons to this repository, so it can be run directly via jsdelivr.
