### PR TITLE
fix: show empty yaml correctly

### DIFF
--- a/app/parser/yaml.ts
+++ b/app/parser/yaml.ts
@@ -19,7 +19,10 @@ const yamlParser: Parser<
   },
   pkgName: 'yaml',
   parse(code, options) {
-    return this.parseAllDocuments(code, { ...options })
+    const documents = this.parseAllDocuments(code, { ...options })
+    return 'empty' in documents && documents.empty
+      ? { ...documents }
+      : documents
   },
   getNodeLocation: genGetNodeLocation('range'),
 }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Turns out the return type of `parseAllDocuments` is not a simple array.

Before:

<img width="1109" height="195" alt="image" src="https://github.com/user-attachments/assets/88841dab-54e5-4c59-af8d-0402f50e343d" />

After:

<img width="1170" height="268" alt="image" src="https://github.com/user-attachments/assets/36ba75c6-ad48-49b4-aee4-89c4217d9296" />


### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
