### PR TITLE
feat: add rehype-parse options

### DIFF
--- a/app/parser/html.ts
+++ b/app/parser/html.ts
@@ -5,6 +5,7 @@ import type * as AngularHtmlParser from 'angular-html-parser'
 import type * as Htmlparser2 from 'htmlparser2'
 import type * as Parse5 from 'parse5'
 import type * as Rehype from 'rehype'
+import type { Options as RehypeParseOptions } from 'rehype-parse'
 import type * as Ultrahtml from 'ultrahtml'
 
 // @unocss-include
@@ -29,20 +30,24 @@ const htmlparser2: Parser<typeof Htmlparser2, Htmlparser2.Options> = {
   hideKeys: ['parent', 'prev', 'next'],
 }
 
-const rehypeAst: Parser<typeof Rehype> = {
+const rehypeAst: Parser<typeof Rehype, RehypeParseOptions> = {
   id: 'rehype',
   label: 'rehype',
   icon: 'https://avatars.githubusercontent.com/u/25711728',
   link: 'https://github.com/rehypejs/rehype',
   editorLanguage: 'html',
   options: {
-    configurable: false,
-    defaultValue: {},
-    editorLanguage: 'javascript',
+    configurable: true,
+    defaultValue: {
+      fragment: false,
+      space: 'html',
+      verbose: false,
+    },
+    editorLanguage: 'json',
   },
   pkgName: 'rehype',
-  parse(code) {
-    return this.rehype().parse(code)
+  parse(code, options) {
+    return this.rehype().data('settings', options).parse(code)
   },
   getNodeLocation: genGetNodeLocation('positionOffset'),
 }

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "puppeteer-core": "catalog:",
     "pyodide": "catalog:parser",
     "rehype": "catalog:parser",
+    "rehype-parse": "catalog:parser",
     "remark": "catalog:parser",
     "rolldown": "catalog:",
     "serve": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,6 +241,9 @@ catalogs:
     rehype:
       specifier: ^13.0.2
       version: 13.0.2
+    rehype-parse:
+      specifier: ^9.0.1
+      version: 9.0.1
     remark:
       specifier: ^15.0.1
       version: 15.0.1
@@ -487,6 +490,9 @@ importers:
       rehype:
         specifier: catalog:parser
         version: 13.0.2
+      rehype-parse:
+        specifier: catalog:parser
+        version: 9.0.1
       remark:
         specifier: catalog:parser
         version: 15.0.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -84,6 +84,7 @@ catalogs:
     protobufjs: ^8.6.3
     pyodide: ^314.0.0
     rehype: ^13.0.2
+    rehype-parse: ^9.0.1
     remark: ^15.0.1
     sql-parser-cst: ^0.42.1
     svelte: ^5.56.3


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

This PR does not contain AI-generated code.

### Description

Currently it's not possible to specify the options passed to `rehype-parse` when parsing HTML. This PR exposes them so that e.g. HTML fragments can be parsed correctly.

### Linked Issues

#276 

### Additional context

Since `rehype` doesn't seem to expose the `rehype-parse` options type, I've added the latter as an explicit dependency.