### PR TITLE
fix: remember parser options

### DIFF
--- a/app/components/navbar/Navbar.vue
+++ b/app/components/navbar/Navbar.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { parseCost } from '~/state/parser/module'
+import { resetParserOptions } from '~/state/parser/options'
 import {
   currentParser,
   displayVersion,
@@ -55,6 +56,18 @@ function editVersion() {
           nav-button
           tooltip="Parser Options"
         />
+        <AppTooltip
+          v-if="currentParser.options.configurable"
+          text="Reset Parser Options"
+        >
+          <button
+            aria-label="Reset Parser Options"
+            nav-button
+            @click="resetParserOptions"
+          >
+            <div i-ri:reset-left-line />
+          </button>
+        </AppTooltip>
       </div>
     </div>
 

--- a/app/state/parser/options.ts
+++ b/app/state/parser/options.ts
@@ -3,6 +3,8 @@ import { currentParser, currentParserId } from './parser'
 
 export const rawOptions = ref('')
 
+const rawOptionsByParser = new Map<string, string>()
+
 const parsedOptions = computed<{ value?: any; error?: unknown }>(() => {
   try {
     const value =
@@ -47,6 +49,19 @@ export function useOptions<O extends object, T>(
 }
 
 export function initParserOptionsState() {
-  // set default options
-  watch(currentParserId, setDefaultOptions, { flush: 'sync' })
+  watch(
+    currentParserId,
+    (parserId, previousParserId) => {
+      if (previousParserId) {
+        rawOptionsByParser.set(previousParserId, rawOptions.value)
+      }
+
+      const savedOptions = parserId
+        ? rawOptionsByParser.get(parserId)
+        : undefined
+      if (savedOptions === undefined) setDefaultOptions()
+      else rawOptions.value = savedOptions
+    },
+    { flush: 'sync' },
+  )
 }

--- a/app/state/parser/options.ts
+++ b/app/state/parser/options.ts
@@ -3,7 +3,10 @@ import { currentParser, currentParserId } from './parser'
 
 export const rawOptions = ref('')
 
-const rawOptionsByParser = new Map<string, string>()
+const rawOptionsByParser = useLocalStorage<Record<string, string>>(
+  `${STORAGE_PREFIX}parser-options`,
+  {},
+)
 
 const parsedOptions = computed<{ value?: any; error?: unknown }>(() => {
   try {
@@ -26,11 +29,19 @@ export const parserOptions = computed({
   },
 })
 
+function getDefaultOptions() {
+  return currentParser.value.options.defaultValueType === 'javascript'
+    ? currentParser.value.options.defaultValue
+    : JSON.stringify(currentParser.value.options.defaultValue, null, 2)
+}
+
 export function setDefaultOptions() {
-  rawOptions.value =
-    currentParser.value.options.defaultValueType === 'javascript'
-      ? currentParser.value.options.defaultValue
-      : JSON.stringify(currentParser.value.options.defaultValue, null, 2)
+  rawOptions.value = getDefaultOptions()
+}
+
+export function resetParserOptions() {
+  delete rawOptionsByParser.value[currentParser.value.id]
+  setDefaultOptions()
 }
 
 export function useOptions<O extends object, T>(
@@ -51,17 +62,26 @@ export function useOptions<O extends object, T>(
 export function initParserOptionsState() {
   watch(
     currentParserId,
-    (parserId, previousParserId) => {
-      if (previousParserId) {
-        rawOptionsByParser.set(previousParserId, rawOptions.value)
-      }
-
+    (parserId) => {
       const savedOptions = parserId
-        ? rawOptionsByParser.get(parserId)
+        ? rawOptionsByParser.value[parserId]
         : undefined
       if (savedOptions === undefined) setDefaultOptions()
       else rawOptions.value = savedOptions
     },
     { flush: 'sync' },
+  )
+
+  watch(
+    rawOptions,
+    (options) => {
+      const parserId = currentParser.value.id
+      if (options === getDefaultOptions()) {
+        delete rawOptionsByParser.value[parserId]
+      } else {
+        rawOptionsByParser.value[parserId] = options
+      }
+    },
+    { flush: 'sync', immediate: true },
   )
 }


### PR DESCRIPTION
### AI usage

- [ ] No AI was used in this PR.
- [x] AI was used: Codex + GPT-5.6 Sol
  - [x] I have carefully reviewed the AI-generated content myself.

### Description

Keep parser option text in memory by parser ID and restore it when switching back, while parsers that have not been selected still initialize from their own defaults.

### Linked Issues

fix #175

### Additional context

Validated with `pnpm run lint`, `pnpm run typecheck`, and `pnpm run build-parser`.
