### PR TITLE
fix(ember): load ember-estree from esm.sh without bundling

### DIFF
--- a/app/parser/ember.ts
+++ b/app/parser/ember.ts
@@ -17,7 +17,7 @@ export const emberEstreeGJS: Parser<typeof EmberESTree, ParseOptions> = {
   },
   pkgName: 'ember-estree',
   getModuleUrl: (pkgId) =>
-    `https://esm.sh/${pkgId}?bundle&target=esnext&exports=parse`,
+    `https://esm.sh/${pkgId}?target=esnext&exports=parse`,
   parse(code, options) {
     const result = this.parse(code, {
       ...options,
@@ -43,7 +43,7 @@ export const emberEstreeGTS: Parser<typeof EmberESTree, ParseOptions> = {
   },
   pkgName: 'ember-estree',
   getModuleUrl: (pkgId) =>
-    `https://esm.sh/${pkgId}?bundle&target=esnext&exports=parse`,
+    `https://esm.sh/${pkgId}?target=esnext&exports=parse`,
   parse(code, options) {
     const result = this.parse(code, {
       ...options,


### PR DESCRIPTION
- [x] This PR contains AI-generated code, **but I have carefully reviewed it myself**. Otherwise, my PR may be closed.
  - [x] I understand that my PR is more likely to be rejected or requested for changes if it contains AI-generated code that I do not fully understand.

### Description

The Ember parsers fail on page load with a WASM error:

```
GET https://esm.sh/ember-estree@0.8.1/esnext/content_tag_bg.wasm -> 404
TypeError: Failed to execute 'compile' on 'WebAssembly': HTTP status code is not ok
```

Cause: the `bundle` flag inlines content-tag into the ember-estree module. content-tag then resolves its WASM file relative to the bundle URL, and esm.sh has no file there. Every ember-estree version fails the same way, so the cause is on the esm.sh side.

Fix: drop `bundle` from the module URL. esm.sh then serves content-tag as its own module and finds the WASM file. Verified in headless Chrome for both GJS and GTS.

cc @NullVoxPopuli for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YEe7R2bgCtu59BaeZSYwin
